### PR TITLE
Improve child_process stdio & support passing extra cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,50 @@
 # install-self-peers
 
-```
-npm i --save-dev @team-griffin/install-self-peers
-
-yarn add --dev @team-griffin/install-self-peers
-```
-
 A cli utility to automatically install the peer dependencies of the package you are developing.
 This is useful for if you are developing a library and some of your dependencies are actually peers.
 
 For example building react based libs.
 
+
+```shell
+npm i --save-dev @team-griffin/install-self-peers
+
+yarn add --dev @team-griffin/install-self-peers
+```
+
 ## Usage
 
-This package creates a bin, which you can execute at `./node_modules/.bin/install-self-peers`.
+#### Manual
 
-## Args
+This package creates a bin, which you can execute:
 
-*--npm* (defaults: false) - This will generate an npm command rather than yarn
+```shell
+$ ./node_modules/.bin/install-self-peers
+```
 
-*--no-execute* - Will print to stdout instead of executing the command
+#### Post-install script
+
+Add the following script in `package.json` to trigger the cli after installing dependencies during development.
+
+```json
+{
+  "scripts": {
+    "postinstall": "install-self-peers -- --ignore-scripts"
+  }
+}
+```
+
+## Arguments
+
+**`--npm`** (defaults: false) - This will generate an npm command rather than yarn
+
+**`--no-execute`** - Will print to stdout instead of executing the command
+
+Other args can be passed directly to `yarn`/`npm` by using **`--`**:  
+**`install-self-peers -- --ignore-scripts`**
+
+## License
+
+MIT License
+
+Copyright (c) 2017

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 const { readFileSync } = require('fs');
 const {
   generateYarnCLICommand,
@@ -22,12 +22,16 @@ const generatorFn = ((npm) => {
 })(argv.npm);
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
-const command = generatorFn(pkg.peerDependencies);
+const commandConfig = generatorFn(pkg.peerDependencies);
+commandConfig.args = commandConfig.args.concat(argv._);
 
 if(argv.execute === true) {
-  exec(command, function(error, stdout, stderr) {
-    console.log(stdout);
-  });
+  const cli = spawn(
+    commandConfig.cmd,
+    commandConfig.args,
+    { stdio: 'inherit' }
+  );
+  cli.on('close', () => process.exit());
 } else {
   console.log(command);
   return;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,21 +1,26 @@
-const { mapObjIndexed, values, join, compose } = require('ramda');
+const { mapObjIndexed, values, compose } = require('ramda');
 
 const mapPeerDependenciesToInstallArg = mapObjIndexed((version, peerPkg) => {
   return `${peerPkg}@${version}`;
 });
 
 const mapPeerDependenciesToCLIArgs = compose(
-  join(' '),
   values,
   mapPeerDependenciesToInstallArg
 );
 
 const prependNpmCommand = (args) => {
-  return `npm install ${args}`;
+  return {
+    cmd: 'npm',
+    args: [ 'install' ].concat(args)
+  };
 };
 
 const prependYarnCommand = (args) => {
-  return `yarn add --peer ${args}`;
+  return {
+    cmd: 'yarn',
+    args: [ 'add', '--peer' ].concat(args)
+  };
 };
 
 const generateYarnCLICommand = compose(


### PR DESCRIPTION
Hey folks!

Great CLI idea.

I've fixed:

* shell escape issues caused by deps with version ranges. eg `>=15.5.4 <=16.0.0` would break cli
* added an example for using the cli in `package.json` scripts, which I consider a core use case
